### PR TITLE
fix(notifiers) Correctly store the webhook url when reading

### DIFF
--- a/scalingo/resource_scalingo_notifier.go
+++ b/scalingo/resource_scalingo_notifier.go
@@ -236,6 +236,12 @@ func setFromScNotifier(d *schema.ResourceData, c scalingo.API, notifier *scaling
 
 	typeData := notifier.Specialize().TypeDataMap()
 	for key, value := range typeData {
+		// GoScalingo calls the Webhook URL type data: "webhook url"
+		// However in this provider, we call it "webhook_url"
+		// This handles the translation
+		if key == "webhook url" {
+			key = "webhook_url"
+		}
 		values[key] = value
 	}
 


### PR DESCRIPTION
Fix #41