### PR TITLE
feat(provider): implement data source region

### DIFF
--- a/scalingo/data_scalingo_region.go
+++ b/scalingo/data_scalingo_region.go
@@ -1,0 +1,86 @@
+package scalingo
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/Scalingo/go-scalingo/v5"
+)
+
+func dataSourceScRegion() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceScRegionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"api": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dashboard": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"database_api": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ssh": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceScRegionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, _ := meta.(*scalingo.Client)
+
+	regions, err := client.RegionsList(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	name, ok := d.Get("name").(string)
+	if !ok || name == "" {
+		return diag.Errorf("name attribute is mandatory")
+	}
+
+	hasSelected := false
+	var selected scalingo.Region
+	for _, v := range regions {
+		if v.Name == name {
+			selected = v
+			hasSelected = true
+			break
+		}
+	}
+
+	if !hasSelected {
+		return diag.Errorf("notification platform '%v' not found", name)
+	}
+
+	d.SetId(selected.Name)
+	err = SetAll(d, map[string]interface{}{
+		"name":         selected.Name,
+		"display_name": selected.DisplayName,
+		"api":          selected.API,
+		"dashboard":    selected.Dashboard,
+		"database_api": selected.DatabaseAPI,
+		"ssh":          selected.SSH,
+	})
+	if err != nil {
+		return diag.Errorf("fail to store notification platform attributes: %v", err)
+	}
+
+	return nil
+}

--- a/scalingo/data_scalingo_region.go
+++ b/scalingo/data_scalingo_region.go
@@ -50,23 +50,18 @@ func dataSourceScRegionsRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	name, ok := d.Get("name").(string)
-	if !ok || name == "" {
-		return diag.Errorf("name attribute is mandatory")
-	}
+	name, _ := d.Get("name").(string)
 
-	hasSelected := false
 	var selected scalingo.Region
 	for _, v := range regions {
 		if v.Name == name {
 			selected = v
-			hasSelected = true
 			break
 		}
 	}
 
-	if !hasSelected {
-		return diag.Errorf("notification platform '%v' not found", name)
+	if selected == (scalingo.Region{}) {
+		return diag.Errorf("region '%v' not found", name)
 	}
 
 	d.SetId(selected.Name)
@@ -79,7 +74,7 @@ func dataSourceScRegionsRead(ctx context.Context, d *schema.ResourceData, meta i
 		"ssh":          selected.SSH,
 	})
 	if err != nil {
-		return diag.Errorf("fail to store notification platform attributes: %v", err)
+		return diag.FromErr(err)
 	}
 
 	return nil

--- a/scalingo/provider.go
+++ b/scalingo/provider.go
@@ -41,6 +41,7 @@ func Provider() *schema.Provider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"scalingo_notification_platform": dataSourceScNotificationPlatform(),
+			"scalingo_region":                dataSourceScRegion(),
 			"scalingo_stack":                 dataSourceScStack(),
 		},
 		ResourcesMap: map[string]*schema.Resource{


### PR DESCRIPTION
scalingo_region usage:

```terraform
data "scalingo_region" "ex_data" {
  name = "osc-fr1"
}

# Create a new Scalingo app
resource "scalingo_app" "terra_ex" {
  name = "my-app"
  environment = {
    "DATA_NAME" = data.scalingo_region.ex_data.name
    "DATA_DISPLAY_NAME" = data.scalingo_region.ex_data.display_name
    "DATA_API" = data.scalingo_region.ex_data.api
    "DATA_DASHBOARD" = data.scalingo_region.ex_data.dashboard
    "DATA_DATABASE_API" = data.scalingo_region.ex_data.database_api
    "DATA_DATABASE_SSH" = data.scalingo_region.ex_data.ssh
  }
}
```

Fix #53