### PR TITLE
feat(data provider): implement data provider container size

### DIFF
--- a/scalingo/data_scalingo_container_size.go
+++ b/scalingo/data_scalingo_container_size.go
@@ -1,0 +1,103 @@
+package scalingo
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/Scalingo/go-scalingo/v5"
+)
+
+func dataSourceScContainerSize() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceScContainerSizeRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sku": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"human_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"human_cpu": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"memory": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"pids_limit": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"hourly_price": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"thirtydays_price": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"swap": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"ordinal": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// dataSourceScNotificationPlatformRead performs the Scalingo API lookup
+func dataSourceScContainerSizeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, _ := meta.(*scalingo.Client)
+
+	containers, err := client.ContainerSizesList(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	name, _ := d.Get("name").(string)
+
+	i := 0
+	for i < len(containers) && containers[i].Name != name {
+		i++
+	}
+	if i >= len(containers) {
+		return diag.Errorf("container '%v' not found", name)
+	}
+
+	d.SetId(containers[i].ID)
+	err = SetAll(d, map[string]interface{}{
+		"name":             containers[i].Name,
+		"id":               containers[i].ID,
+		"sku":              containers[i].SKU,
+		"human_name":       containers[i].HumanName,
+		"human_cpu":        containers[i].HumanCPU,
+		"memory":           containers[i].Memory,
+		"pids_limit":       containers[i].PidsLimit,
+		"hourly_price":     containers[i].HourlyPrice,
+		"thirtydays_price": containers[i].ThirtydaysPrice,
+		"swap":             containers[i].Swap,
+		"ordinal":          containers[i].Ordinal,
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/scalingo/provider.go
+++ b/scalingo/provider.go
@@ -43,6 +43,7 @@ func Provider() *schema.Provider {
 			"scalingo_notification_platform": dataSourceScNotificationPlatform(),
 			"scalingo_region":                dataSourceScRegion(),
 			"scalingo_stack":                 dataSourceScStack(),
+			"scalingo_container_size":        dataSourceScContainerSize(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"scalingo_addon":           resourceScalingoAddon(),


### PR DESCRIPTION
data provider container size usage:
```terraform
data "scalingo_container_size" "ex_data" {
  name = "L"
}

# Create a new Scalingo app
resource "scalingo_app" "terra_test" {
  name = "escudierq-terraform"
  environment = {
    "CONTAINER_ID" = data.scalingo_container_size.ex_data.id
    "CONTAINER_NAME" = data.scalingo_container_size.ex_data.name
    "CONTAINER_SKU" = data.scalingo_container_size.ex_data.sku
    "CONTAINER_HUMAN_NAME" = data.scalingo_container_size.ex_data.human_name
    "CONTAINER_HUMAN_CPU" = data.scalingo_container_size.ex_data.human_cpu
    "CONTAINER_MEMORY" = data.scalingo_container_size.ex_data.memory
    "CONTAINER_PIDS_LIMIT" = data.scalingo_container_size.ex_data.pids_limit
    "CONTAINER_HOURLY_PRICE" = data.scalingo_container_size.ex_data.hourly_price
    "CONTAINER_THIRTY_DAYS_PRICE" = data.scalingo_container_size.ex_data.thirtydays_price
    "CONTAINER_SWAP" = data.scalingo_container_size.ex_data.swap
    "CONTAINER_ORDINAL" = data.scalingo_container_size.ex_data.ordinal
  }
}
```

Fix #51