### PR TITLE
resource(app) Correctly handle stack change by modifying 'stack_id' field, add extra logging also

### DIFF
--- a/scalingo/data_scalingo_stack.go
+++ b/scalingo/data_scalingo_stack.go
@@ -2,7 +2,9 @@ package scalingo
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -34,11 +36,6 @@ func dataSourceScStack() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Is it the current default stack?",
-			},
-			"id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "ID of the stack",
 			},
 			"deprecated_at": {
 				Type:        schema.TypeString,
@@ -75,13 +72,16 @@ func dataSourceScStackRead(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("fail to find stack with name '%s'", name)
 	}
 
-	d.SetId(selected.ID)
-	err = SetAll(d, map[string]interface{}{
+	stackFields := map[string]interface{}{
 		"name":        selected.Name,
 		"description": selected.Description,
 		"base_image":  selected.BaseImage,
 		"default":     selected.Default,
-	})
+	}
+	tflog.Info(ctx, fmt.Sprintf("Fetched stack '%v' with ID %v", name, selected.ID), stackFields)
+
+	d.SetId(selected.ID)
+	err = SetAll(d, stackFields)
 	if err != nil {
 		return diag.Errorf("fail to save stack information: %v", err)
 	}

--- a/scalingo/resource_scalingo_app.go
+++ b/scalingo/resource_scalingo_app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -54,15 +55,9 @@ func resourceScalingoApp() *schema.Resource {
 				Type: schema.TypeString,
 				// Either set by the user, either set automatically by server if
 				// no value is provided
-				Optional: true,
-				Computed: true,
-				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
-					if newValue == "" {
-						return true
-					}
-					return true
-				},
-				Description: "ID of the base stack to use (scalingo-18/scalingo-20)",
+				Optional:    true,
+				Computed:    true,
+				Description: "ID of the base stack to use (scalingo-18/scalingo-20/scalingo-22)",
 			},
 		},
 
@@ -86,6 +81,10 @@ func resourceAppCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		createOpts.StackID = stackID
 	}
 
+	tflog.Info(ctx, "Creating Scalingo application", map[string]interface{}{
+		"name":     createOpts.Name,
+		"stack_id": createOpts.StackID,
+	})
 	app, err := client.AppsCreate(ctx, createOpts)
 	if err != nil {
 		return diag.Errorf("fail to create app: %v", err)
@@ -97,6 +96,7 @@ func resourceAppCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		"git_url":  app.GitURL,
 		"stack_id": app.StackID,
 	})
+
 	if err != nil {
 		return diag.Errorf("fail to store application attributes: %v", err)
 	}


### PR DESCRIPTION
Without this PR, changing the `stack_id` always return true, considering there is no diff between 'stack_id', that's why SuppressDiffFunc is deleted. I've no idea why it was initially introduced, but one thing is sure, it's thats it disturbs the expected behavior.

Fixes #116