### PR TITLE
Update terraform doc to match current version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ resource "scalingo_app" "my-app" {
 }
 
 # Provision a highly available PostgreSQL cluster and attach it to the application
-resource "scalingo_app" "my-db" {
+resource "scalingo_addon" "my-db" {
   provider_id = "postgresql"
   plan = "postgresql-business-1024"
   app = "${scalingo_app.my-app.id}"
@@ -32,7 +32,7 @@ resource "scalingo_app" "my-db" {
 
 # Configure domain 'example.com' to be targeting your application
 resource "scalingo_domain" "my-domain" {
-  name = "example.com"
+  common_name = "example.com"
   app = "${scalingo_app.my-app.id}"
 }
 ```


### PR DESCRIPTION
The online doc is a broken terraform config. I fixed the postgresql (that should be an addon, not an app) and the domain (that should have a canonical_name, not a name)