### PR TITLE
chore: add default value for events and alerts in notifier schema

### DIFF
--- a/scalingo/resource_scalingo_notifier.go
+++ b/scalingo/resource_scalingo_notifier.go
@@ -54,11 +54,13 @@ func resourceScalingoNotifier() *schema.Resource {
 			"send_all_events": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Default:     false,
 				Description: "Send notifications for all types of events of the application if true",
 			},
 			"selected_events": {
 				Type:        schema.TypeSet,
 				Optional:    true,
+				Default:     false,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Allowlist of event types to filter which should trigger notifications",
 			},
@@ -77,12 +79,12 @@ func resourceScalingoNotifier() *schema.Resource {
 			"webhook_url": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Destination URL which should receive notifications (for notifier platform 'webhook')",
+				Description: "Destination URL which should receive notifications (for notifier platforms 'slack', 'rocket_chat' and 'webhook')",
 			},
 			"type": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Human readable notifier type (slack/webhook/email/etc.)",
+				Description: "Human readable notifier type (slack/webhook/email/rocket_chat/etc.)",
 			},
 		},
 	}


### PR DESCRIPTION
I saw that the default value definitions for `send_all_alerts` and `send_all_events` were missing, and since on the dashboard they are unchecked by default, I have a default value of `false`, but feel free to tell me if this is not a good idea.

Thanks for the incredible recent improvement on this provider!