### PR TITLE
No default for set, it's invalid configuration

### DIFF
--- a/scalingo/resource_scalingo_notifier.go
+++ b/scalingo/resource_scalingo_notifier.go
@@ -60,7 +60,6 @@ func resourceScalingoNotifier() *schema.Resource {
 			"selected_events": {
 				Type:        schema.TypeSet,
 				Optional:    true,
-				Default:     false,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Allowlist of event types to filter which should trigger notifications",
 			},


### PR DESCRIPTION
Review of  https://github.com/Scalingo/terraform-provider-scalingo/pull/139

```
.ci/specs
/gco 'refacto/types-deployment' Specs probably need the .env.test file
?   	github.com/Scalingo/terraform-provider-scalingo	[no test files]
--- FAIL: TestProvider (0.00s)
    provider_test.go:9: err: 1 error occurred:
        	* resource scalingo_notifier: selected_events: Default is not valid for lists or sets

FAIL
FAIL	github.com/Scalingo/terraform-provider-scalingo/scalingo	0.027s
FAIL
```
