### PR TITLE
fix(resource_scalingo_container_type): make amount mandatory

### DIFF
--- a/scalingo/resource_scalingo_container_type.go
+++ b/scalingo/resource_scalingo_container_type.go
@@ -33,7 +33,7 @@ func resourceScalingoContainerType() *schema.Resource {
 			},
 			"amount": {
 				Type:        schema.TypeInt,
-				Optional:    true,
+				Required:    true,
 				Description: "Number of containers to boot for this type",
 			},
 			"size": {


### PR DESCRIPTION
Make amount mandatory when creating/updating a container type resource (like it is in the API).

Fixes #183